### PR TITLE
Initial changes for improved CosmosDB performance

### DIFF
--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -39,15 +39,12 @@ func NewBufferedBulkInserter(collection *mgo.Collection, docLimit int,
 		continueOnError: continueOnError,
 		docLimit:        docLimit,
 	}
-	log.Logvf(log.Always, "Document Limit: %d", docLimit)
-	log.Logvf(log.Always, "Unordered: %t", bb.unordered)
 	bb.resetBulk()
 	return bb
 }
 
 func (bb *BufferedBulkInserter) Unordered() {
 	bb.unordered = true
-	log.Logvf(log.Always, "Unordered has changed to: %t", bb.unordered)
 	bb.bulk.Unordered()
 }
 
@@ -94,12 +91,12 @@ retry:
 
 			failedInsertCount++
 			coolDownTime := 250 * failedInsertCount
-			log.Logvf(log.Always, "We're overloading CosmosDB; let's wait %d milliseconds", coolDownTime)
+			log.Logvf(log.Always, "We're overloading Azure CosmosDB; let's wait %d milliseconds", coolDownTime)
 
 			cooldownTimer := time.NewTimer(time.Duration(coolDownTime) * time.Millisecond)
 			<-cooldownTimer.C
 
-			log.Logv(log.Always, "Let's retry now!")
+			log.Logv(log.Always, "Retrying now!")
 			goto retry
 		}
 		return err

--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -8,6 +8,10 @@ package db
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mongodb/mongo-tools/common/log"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -63,13 +67,38 @@ func (bb *BufferedBulkInserter) Insert(doc interface{}) error {
 	}
 	// flush if we are full
 	if bb.docCount >= bb.docLimit || bb.byteCount+len(rawBytes) > MaxBSONSize {
-		err = bb.Flush()
+		err = bb.FlushWithRetry()
 	}
 	// buffer the document
 	bb.docCount++
 	bb.byteCount += len(rawBytes)
 	bb.bulk.Insert(bson.Raw{Data: rawBytes})
 	return err
+}
+
+// FlushWithRetry continously writes all buffered documents in one bulk insert until there's no error then resets the buffer.
+func (bb *BufferedBulkInserter) FlushWithRetry() error {
+	failedInsertCount := 0
+	if bb.docCount == 0 {
+		return nil
+	}
+	defer bb.resetBulk()
+retry:
+	if _, err := bb.bulk.Run(); err != nil {
+		if strings.Contains(err.Error(), "Request rate is large") || strings.Contains(err.Error(), "The request rate is too large") {
+			failedInsertCount++
+			coolDownTime := 250 * failedInsertCount
+			log.Logvf(log.Always, "We're overloading CosmosDB; let's wait %d milliseconds", coolDownTime)
+
+			cooldownTimer := time.NewTimer(time.Duration(coolDownTime) * time.Millisecond)
+			<-cooldownTimer.C
+
+			log.Logv(log.Always, "Let's retry now!")
+			goto retry
+		}
+		return err
+	}
+	return nil
 }
 
 // Flush writes all buffered documents in one bulk insert then resets the buffer.

--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -39,12 +39,15 @@ func NewBufferedBulkInserter(collection *mgo.Collection, docLimit int,
 		continueOnError: continueOnError,
 		docLimit:        docLimit,
 	}
+	log.Logvf(log.Always, "Document Limit: %d", docLimit)
+	log.Logvf(log.Always, "Unordered: %t", bb.unordered)
 	bb.resetBulk()
 	return bb
 }
 
 func (bb *BufferedBulkInserter) Unordered() {
 	bb.unordered = true
+	log.Logvf(log.Always, "Unordered has changed to: %t", bb.unordered)
 	bb.bulk.Unordered()
 }
 

--- a/common/db/buffered_bulk.go
+++ b/common/db/buffered_bulk.go
@@ -88,7 +88,10 @@ func (bb *BufferedBulkInserter) FlushWithRetry() error {
 	defer bb.resetBulk()
 retry:
 	if _, err := bb.bulk.Run(); err != nil {
-		if strings.Contains(err.Error(), "Request rate is large") || strings.Contains(err.Error(), "The request rate is too large") {
+		if strings.Contains(err.Error(), "Request rate is large") ||
+			strings.Contains(err.Error(), "The request rate is too large") ||
+			strings.Contains(err.Error(), "Partition key provided either doesn't correspond") {
+
 			failedInsertCount++
 			coolDownTime := 250 * failedInsertCount
 			log.Logvf(log.Always, "We're overloading CosmosDB; let's wait %d milliseconds", coolDownTime)

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -10,6 +10,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
@@ -19,7 +20,13 @@ import (
 	"github.com/mongodb/mongo-tools/mongoimport"
 )
 
+func timeTrack(start time.Time, name string) {
+	elapsed := time.Since(start)
+	log.Logvf(log.Always, "%s took %s", name, elapsed)
+}
+
 func main() {
+	defer timeTrack(time.Now(), "main")
 	// initialize command-line opts
 	opts := options.New("mongoimport", mongoimport.Usage,
 		options.EnabledOptions{Auth: true, Connection: true, Namespace: true, URI: true})

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -407,6 +407,7 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (numImported ui
 // or more workers.
 func (imp *MongoImport) ingestDocuments(readDocs chan bson.D) (retErr error) {
 	numInsertionWorkers := imp.IngestOptions.NumInsertionWorkers
+	log.Logvf(log.Always, "InsertionWorkers: %d", numInsertionWorkers)
 	if numInsertionWorkers <= 0 {
 		numInsertionWorkers = 1
 	}
@@ -460,6 +461,7 @@ func (imp *MongoImport) configureSession(session *mgo.Session) error {
 type flushInserter interface {
 	Insert(doc interface{}) error
 	Flush() error
+	FlushWithRetry() error
 }
 
 // runInsertionWorker is a helper to InsertDocuments - it reads document off
@@ -502,7 +504,7 @@ readLoop:
 		}
 	}
 
-	err = inserter.Flush()
+	err = inserter.FlushWithRetry()
 	// TOOLS-349 correct import count for bulk operations
 	if bulkError, ok := err.(*mgo.BulkError); ok {
 		failedDocs := make(map[int]bool) // index of failures
@@ -544,6 +546,12 @@ func (up *upserter) Insert(doc interface{}) error {
 		_, err = up.collection.Upsert(selector, bson.M{"$set": document})
 	}
 	return err
+}
+
+// Flush is needed so that upserter implements flushInserter, but upserter
+// doesn't buffer anything so we don't need to do anything in Flush.
+func (up *upserter) FlushWithRetry() error {
+	return nil
 }
 
 // Flush is needed so that upserter implements flushInserter, but upserter

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -393,8 +393,6 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (numImported ui
 		log.Logvf(log.Always, "Unable to create collection: %s", collection.Name)
 		return 0, errCosmosCol
 	}
-	log.Logvf(log.Always, "Throughput adjusted to %d!", imp.IngestOptions.Throughput)
-
 	readDocs := make(chan bson.D, workerBufferSize)
 	processingErrChan := make(chan error)
 	ordered := imp.IngestOptions.MaintainInsertionOrder
@@ -419,7 +417,6 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (numImported ui
 // or more workers.
 func (imp *MongoImport) ingestDocuments(readDocs chan bson.D) (retErr error) {
 	numInsertionWorkers := imp.IngestOptions.NumInsertionWorkers
-	log.Logvf(log.Always, "InsertionWorkers: %d", numInsertionWorkers)
 	if numInsertionWorkers <= 0 {
 		numInsertionWorkers = 1
 	}
@@ -560,8 +557,8 @@ func (up *upserter) Insert(doc interface{}) error {
 	return err
 }
 
-// Flush is needed so that upserter implements flushInserter, but upserter
-// doesn't buffer anything so we don't need to do anything in Flush.
+// FlushWithRetry is needed so that upserter implements flushInserter, but upserter
+// doesn't buffer anything so we don't need to do anything in FlushWithRetry.
 func (up *upserter) FlushWithRetry() error {
 	return nil
 }

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -88,7 +88,7 @@ type IngestOptions struct {
 	BulkBufferSize int `long:"batchSize" default:"1000" hidden:"true"`
 
 	// Indicate the amount of throughput to set the Azure CosmosDB collections to
-	Throughput int `short:"t" value-name:"<number>" long:"throughput" description:"Throughput to set on a CosmosDB collection" default:"3000"`
+	Throughput int `short:"t" value-name:"<number>" long:"throughput" description:"Throughput to set on a CosmosDB collection" default:"10000"`
 
 	// Specify the Shard key for Azure CosmosDB to perform sharding with
 	ShardKey string `long:"shardKey" value-name:"<field>" description:"Shard key for CosmosDB; specifying this key will set the collection size to be 'Unlimited' instead of 'Fixed', which also raises the maximum RU from 10k to 50k"`

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -86,6 +86,12 @@ type IngestOptions struct {
 	NumDecodingWorkers int `long:"numDecodingWorkers" default:"0" hidden:"true"`
 
 	BulkBufferSize int `long:"batchSize" default:"1000" hidden:"true"`
+
+	// Indicate the amount of throughput to set the Azure CosmosDB collections to
+	Throughput int `short:"t" value-name:"<number>" long:"throughput" description:"Throughput to set on a CosmosDB collection" default:"3000"`
+
+	// Specify the Shard key for Azure CosmosDB to perform sharding with
+	ShardKey string `long:"shardKey" value-name:"<field>" description:"Shard key for CosmosDB; specifying this key will set the collection size to be 'Unlimited' instead of 'Fixed', which also raises the maximum RU from 10k to 50k"`
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -85,7 +85,7 @@ type IngestOptions struct {
 	// Specifies the number of threads to use in processing data read from the input source
 	NumDecodingWorkers int `long:"numDecodingWorkers" default:"0" hidden:"true"`
 
-	BulkBufferSize int `long:"batchSize" default:"250" hidden:"true"`
+	BulkBufferSize int `long:"batchSize" default:"100" hidden:"true"`
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -92,7 +92,6 @@ type IngestOptions struct {
 
 	// Specify the Shard key for Azure CosmosDB to perform sharding with
 	ShardKey string `long:"shardKey" value-name:"<field>" description:"Shard key for CosmosDB; specifying this key will set the collection size to be 'Unlimited' instead of 'Fixed', which also raises the maximum RU from 10k to 50k"`
->>>>>>> cosmosParams
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -85,7 +85,7 @@ type IngestOptions struct {
 	// Specifies the number of threads to use in processing data read from the input source
 	NumDecodingWorkers int `long:"numDecodingWorkers" default:"0" hidden:"true"`
 
-	BulkBufferSize int `long:"batchSize" default:"100" hidden:"true"`
+	BulkBufferSize int `long:"batchSize" default:"400" hidden:"true"`
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -85,7 +85,7 @@ type IngestOptions struct {
 	// Specifies the number of threads to use in processing data read from the input source
 	NumDecodingWorkers int `long:"numDecodingWorkers" default:"0" hidden:"true"`
 
-	BulkBufferSize int `long:"batchSize" default:"1000" hidden:"true"`
+	BulkBufferSize int `long:"batchSize" default:"250" hidden:"true"`
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/vendor/src/gopkg.in/mgo.v2/session.go
+++ b/vendor/src/gopkg.in/mgo.v2/session.go
@@ -2856,6 +2856,29 @@ func (c *Collection) Create(info *CollectionInfo) error {
 	return c.Database.Run(cmd, nil)
 }
 
+// The CosmosDBCollectionInfo type holds metadata about a CosmosDB collection.
+type CosmosDBCollectionInfo struct {
+	ShardKey   string
+	Throughput int
+}
+
+// CreateCustomCosmosDB explicitly creates the c collection for
+// Azure CosmosDB, allowing the specification of throughput and shard keys
+func (c *Collection) CreateCustomCosmosDB(info *CosmosDBCollectionInfo) error {
+	cmd := make(bson.D, 0, 4)
+	cmd = append(cmd, bson.DocElem{"customAction", "CreateCollection"})
+	cmd = append(cmd, bson.DocElem{"collection", c.Name})
+
+	//TODO: Validate the throughput range for Fixed & Unlimited
+	cmd = append(cmd, bson.DocElem{"offerThroughput", info.Throughput})
+
+	//TODO: Validate the shardkey to be acceptable
+	if info.ShardKey != "" {
+		cmd = append(cmd, bson.DocElem{"shardKey", info.ShardKey})
+	}
+	return c.Database.Run(cmd, nil)
+}
+
 // Batch sets the batch size used when fetching documents from the database.
 // It's possible to change this setting on a per-session basis as well, using
 // the Batch method of Session.

--- a/vendor/src/gopkg.in/mgo.v2/session.go
+++ b/vendor/src/gopkg.in/mgo.v2/session.go
@@ -2869,10 +2869,10 @@ func (c *Collection) CreateCustomCosmosDB(info *CosmosDBCollectionInfo) error {
 	cmd = append(cmd, bson.DocElem{"customAction", "CreateCollection"})
 	cmd = append(cmd, bson.DocElem{"collection", c.Name})
 
-	//TODO: Validate the throughput range for Fixed & Unlimited
+	//TODO: Validate the throughput range for Fixed & Unlimited collections
 	cmd = append(cmd, bson.DocElem{"offerThroughput", info.Throughput})
 
-	//TODO: Validate the shardkey to be acceptable
+	//TODO: Validate the shardkey to be in an acceptable format
 	if info.ShardKey != "" {
 		cmd = append(cmd, bson.DocElem{"shardKey", info.ShardKey})
 	}


### PR DESCRIPTION
## Main changes
- Add incremental wait & retry upon obtaining request rate too large error
- Allow clients to specify `Throughput` for their Fixed or Unlimited collections
- Allow clients to specify `Shard Key` for their Unlimited collections

### Other changes
- Add simple timer to measure the time importing took