### PR TITLE
Add adaptive worker manager (Scale up only)

### DIFF
--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -17,11 +17,11 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/globalsign/mgo/bson"
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/util"
-	"github.com/globalsign/mgo/bson"
 	"gopkg.in/tomb.v2"
 )
 
@@ -248,7 +248,7 @@ func filterIngestError(stopOnError bool, err error) error {
 	if stopOnError || db.IsConnectionError(err) {
 		return err
 	}
-	log.Logvf(log.Always, "error inserting documents: %v", err)
+	//log.Logvf(log.Always, "error inserting documents: %v", err)
 	return nil
 }
 

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -560,7 +560,6 @@ func (imp *MongoImport) runInsertionWorker(readDocs chan bson.D, manager *Hiring
 		return fmt.Errorf("error configuring session: %v", err)
 	}
 	collection := session.DB(imp.ToolOptions.DB).C(imp.ToolOptions.Collection)
-
 	inserter := imp.newCosmosDbInserter(collection)
 
 readLoop:
@@ -608,12 +607,11 @@ func (imp *MongoImport) newCosmosDbInserter(collection *mgo.Collection) *CosmosD
 	}
 }
 
-// Insert is part of the flushInserter interface and performs
-// upserts or inserts.
 func (ci *CosmosDbInserter) Insert(doc interface{}, manager *HiringManager, workerId int) error {
 	// Prevent the retry from re-creating the insertOp object again by explicitly storing it
 	insertOperation := mgo.CreateInsertOp(ci.collection.FullName, doc.(bson.D))
 	opDeadline := time.Now().Add(5 * time.Second)
+
 retry:
 	err := ci.collection.InsertWithOp(insertOperation)
 	if err != nil {

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -8,6 +8,7 @@
 package mongoimport
 
 import (
+	"math"
 	"runtime"
 
 	"github.com/globalsign/mgo"
@@ -429,35 +430,37 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (numImported ui
 type AddWorkerAction func(h *HiringManager, a int)
 
 type HiringManager struct {
-	latencyRecords       []int64
-	chargeRecords        []int64
-	workerCount          int
-	collectionThroughput int
-	rateLimitCount       int64
-	wg                   *sync.WaitGroup
-	recordWg             *sync.WaitGroup
-	Action               AddWorkerAction
+	latencyRecords     []int64
+	consumptionRecords []int64
+
+	rateLimitCounter int64
+	workerCount      int
+	throughput       int
+
+	workerWg *sync.WaitGroup
+	recordWg *sync.WaitGroup
+	Action   AddWorkerAction
 }
 
-func NewHiringManager(defaultWorkers int, ru int) *HiringManager {
+func NewHiringManager(defaultWorkers int, throughput int) *HiringManager {
 	return &HiringManager{
-		latencyRecords:       make([]int64, 0, defaultWorkers),
-		chargeRecords:        make([]int64, 0, defaultWorkers),
-		workerCount:          0,
-		rateLimitCount:       0,
-		collectionThroughput: ru,
-		wg:                   new(sync.WaitGroup),
-		recordWg:             new(sync.WaitGroup),
-		Action:               nil,
+		latencyRecords:     make([]int64, 0, defaultWorkers),
+		consumptionRecords: make([]int64, 0, defaultWorkers),
+		rateLimitCounter:   0,
+		workerCount:        0,
+		throughput:         throughput,
+		workerWg:           new(sync.WaitGroup),
+		recordWg:           new(sync.WaitGroup),
+		Action:             nil,
 	}
+}
+
+func (h *HiringManager) AwaitAllWorkers() {
+	h.workerWg.Wait()
 }
 
 func (h *HiringManager) CountWorkers() int {
 	return h.workerCount
-}
-
-func (h *HiringManager) Await() {
-	h.wg.Wait()
 }
 
 func (h *HiringManager) CanNotify(workerId int) bool {
@@ -466,107 +469,100 @@ func (h *HiringManager) CanNotify(workerId int) bool {
 
 func (h *HiringManager) Notify(workerId int, latency int64, charge int64) {
 	if latency < 0 {
-		log.Logvf(log.Always, "Bad sample latency")
 		return
 	}
 	defer h.recordWg.Done()
 	atomic.StoreInt64(&h.latencyRecords[workerId], latency)
-	atomic.StoreInt64(&h.chargeRecords[workerId], charge)
-	//log.Logvf(log.Always, "Worker %d reported %d ms and %d RU", workerId, latency, charge)
+	atomic.StoreInt64(&h.consumptionRecords[workerId], charge)
 }
 
-func (h *HiringManager) Start(n int) {
+func (h *HiringManager) Start(n int, imp *MongoImport) {
 	for i := 0; i < n; i++ {
 		h.HireNewWorker()
 	}
 
 	go func() {
-		/*
-			sleepTime := 5 * time.Second
+		sleepTime := 5 * time.Second
 
-				for {
-					time.Sleep(sleepTime)
-					//TODO: Exit condition if workers crash
-					log.Logv(log.Always, "Manager is requesting updates from workers")
+		for {
+			time.Sleep(sleepTime)
+			if !imp.Alive() {
+				return
+			}
 
-					h.recordWg.Add(h.workerCount)
-					for i := 0; i < h.workerCount; i++ {
-						atomic.StoreInt64(&h.latencyRecords[i], -1)
-						atomic.StoreInt64(&h.chargeRecords[i], -1)
-					}
+			h.recordWg.Add(h.workerCount)
+			for i := 0; i < h.workerCount; i++ {
+				atomic.StoreInt64(&h.latencyRecords[i], -1)
+				atomic.StoreInt64(&h.consumptionRecords[i], -1)
+			}
+			h.recordWg.Wait()
 
-					// Await for all workers to fill in their report
-					h.recordWg.Wait()
-					log.Logv(log.Always, "Manager has updates from all workers")
+			var latencySum int64
+			var chargeSum int64
+			for i := 0; i < h.workerCount; i++ {
+				latencySum += atomic.LoadInt64(&h.latencyRecords[i])
+				chargeSum += atomic.LoadInt64(&h.consumptionRecords[i])
+			}
+			averageLatency := latencySum / int64(h.workerCount)
+			averageCharge := chargeSum / int64(h.workerCount)
+			log.Logvf(log.Always, "On average, insertions took %d (ns) and consumed %d RU", averageLatency, averageCharge)
 
-					var latencySum int64
-					var chargeSum int64
-					for i := 0; i < h.workerCount; i++ {
-						latencySum += atomic.LoadInt64(&h.latencyRecords[i])
-						chargeSum += atomic.LoadInt64(&h.chargeRecords[i])
+			amount := int(math.Ceil((float64(h.throughput) * float64(averageLatency) / 1000000.0) / float64(averageCharge)))
+			amountToHire := (amount - h.workerCount) / 2
+			log.Logvf(log.Always, "Target workers %d | Hiring %d", amount, amountToHire)
+			if amountToHire <= 0 || amountToHire > 100 || h.WasRecentlyRateLimited() {
+				break
+			}
 
-					}
-					averageLatency := latencySum / int64(h.workerCount)
-					averageCharge := chargeSum / int64(h.workerCount)
-					log.Logvf(log.Always, "Avg latency %d | avg charge: %d", averageLatency, averageCharge)
+			for i := 0; i < amountToHire; i++ {
+				h.HireNewWorker()
+			}
+			log.Logvf(log.Always, "Manager thinks we can move faster; there are now %d workers", h.workerCount)
+			sleepTime = sleepTime + (3 * time.Second)
+		}
 
-					targetAmount := (float64(h.collectionThroughput) * float64(averageLatency) / 1000000.0) / float64(averageCharge)
-					amount := int(math.Ceil(targetAmount))
-					amountToHire := (amount - h.workerCount) / 2
+		log.Logv(log.Always, "Hiring manager has stopped mass hiring; switching to single hire")
 
-					log.Logvf(log.Always, "Target workers %d | Hiring %d", amount, amountToHire)
-					if amountToHire <= 0 {
-						log.Logv(log.Always, "No need to hire anymore")
-						break
-					}
-					if amountToHire > 100 {
-						log.Logv(log.Always, "Tried to hire too many")
-						break
-					}
-					limitCount := atomic.LoadInt64(&h.rateLimitCount)
-					atomic.StoreInt64(&h.rateLimitCount, 0)
-					if limitCount > 0 {
-						log.Logvf(log.Always, "There was %d `Request rate too large` responses, no extra workers are needed", limitCount)
-						continue
-					}
-					for i := 0; i < amountToHire; i++ {
-						h.HireNewWorker()
-					}
-					log.Logvf(log.Always, "Manager thinks we can move faster; there are now %d workers", h.workerCount)
-					sleepTime = sleepTime + (3 * time.Second)
-				}
-				log.Logv(log.Always, "Hiring manager has stopped mass hiring; switching to single hire")
-		*/
 		for {
 			time.Sleep(5 * time.Second)
-			limitCount := atomic.LoadInt64(&h.rateLimitCount)
-			atomic.StoreInt64(&h.rateLimitCount, 0)
-			if limitCount > 0 {
-				log.Logvf(log.Always, "There was %d `Request rate too large` responses, no extra workers are needed", limitCount)
-				continue
-			} else {
-				h.HireNewWorker()
-				log.Logvf(log.Always, "Manager thinks we can move a bit faster; there are now %d workers", h.workerCount)
+			if !imp.Alive() {
+				return
 			}
+			if h.WasRecentlyRateLimited() {
+				continue
+			}
+
+			h.HireNewWorker()
+			log.Logvf(log.Always, "Manager thinks we can move a bit faster; there are now %d workers", h.workerCount)
 		}
 	}()
 }
 
 func (h *HiringManager) HireNewWorker() {
 	h.latencyRecords = append(h.latencyRecords, 0)
-	h.chargeRecords = append(h.chargeRecords, 0)
+	h.consumptionRecords = append(h.consumptionRecords, 0)
 	newWorkerID := h.workerCount
 	h.workerCount++
 
-	h.wg.Add(1)
+	h.workerWg.Add(1)
 	go func() {
-		defer h.wg.Done()
+		defer h.workerWg.Done()
 		h.Action(h, newWorkerID)
 	}()
 }
 
 func (h *HiringManager) NotifyRateLimit() {
-	atomic.AddInt64(&h.rateLimitCount, 1)
+	atomic.AddInt64(&h.rateLimitCounter, 1)
+}
+
+func (h *HiringManager) WasRecentlyRateLimited() bool {
+	limitCount := atomic.LoadInt64(&h.rateLimitCounter)
+	atomic.StoreInt64(&h.rateLimitCounter, 0)
+	if limitCount > 0 {
+		log.Logvf(log.Always, "There was %d `Request rate too large` responses, no extra workers are needed", limitCount)
+		return true
+	}
+	return false
 }
 
 // ingestDocuments accepts a channel from which it reads documents to be inserted
@@ -586,8 +582,8 @@ func (imp *MongoImport) ingestDocuments(readDocs chan bson.D) (retErr error) {
 			imp.Kill(err)
 		}
 	})
-	manager.Start(numInsertionWorkers)
-	manager.Await()
+	manager.Start(numInsertionWorkers, imp)
+	manager.AwaitAllWorkers()
 	return
 }
 

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -613,7 +613,7 @@ func (ci *CosmosDbInserter) Insert(doc interface{}, manager *HiringManager, work
 	opDeadline := time.Now().Add(5 * time.Second)
 
 retry:
-	err := ci.collection.InsertWithOp(insertOperation)
+	latency, err := ci.collection.InsertWithOp(insertOperation)
 	if err != nil {
 		manager.ResetWorkerSuccess(workerId)
 		if qerr, ok := err.(*mgo.QueryError); ok {
@@ -621,7 +621,7 @@ retry:
 
 			// TooManyRequest
 			case 16500:
-				//log.Logvf(log.Always, "We're overloading Cosmos DB; let's wait")
+				log.Logvf(log.Always, "We're overloading Cosmos DB; let's wait")
 				time.Sleep(5 * time.Millisecond)
 
 				if time.Now().After(opDeadline) {
@@ -641,6 +641,7 @@ retry:
 			log.Logvf(log.Always, "Received something that is not a QueryError: %v", err)
 		}
 	} else {
+		log.Logvf(log.Always, "Latency: %d", latency)
 		manager.IncrementWorkerSuccess(workerId)
 	}
 	return err

--- a/vendor/src/github.com/globalsign/mgo/bulk.go
+++ b/vendor/src/github.com/globalsign/mgo/bulk.go
@@ -324,7 +324,7 @@ func (b *Bulk) runInsert(action *bulkAction, result *BulkResult, berr *BulkError
 	if !b.ordered {
 		op.flags = 1 // ContinueOnError
 	}
-	lerr, err := b.c.RetryableWriteOp(op, b.ordered)
+	lerr, err := b.c.writeOp(op, b.ordered)
 	return b.checkSuccess(action, berr, lerr, err)
 }
 

--- a/vendor/src/github.com/globalsign/mgo/session.go
+++ b/vendor/src/github.com/globalsign/mgo/session.go
@@ -2855,9 +2855,15 @@ func (c *Collection) Insert(docs ...interface{}) error {
 }
 
 // Insert with the insert op directly (For performance)
-func (c *Collection) InsertWithOp(op *InsertOperation) error {
-	_, err := c.writeOp(op.Op, true)
-	return err
+func (c *Collection) InsertWithOp(op *InsertOperation) (latency int64, err error) {
+	startTime := time.Now()
+	_, err = c.writeOp(op.Op, true)
+	endTime := time.Now()
+	latency = endTime.Sub(startTime).Nanoseconds() / 1000
+	if err != nil {
+		return -1, err
+	}
+	return latency, err
 }
 
 // Update finds a single document matching the provided selector document
@@ -3175,7 +3181,6 @@ func (c *Collection) CreateCustomCosmosDB(info *CosmosDBCollectionInfo) error {
 	return c.Database.Run(cmd, nil)
 }
 
-/*
 func (c *Collection) GetLastRequestStatistics() (charge uint, err error) {
 	var result bson.D
 
@@ -3188,7 +3193,7 @@ func (c *Collection) GetLastRequestStatistics() (charge uint, err error) {
 
 	return charge, err
 }
-*/
+
 // Batch sets the batch size used when fetching documents from the database.
 // It's possible to change this setting on a per-session basis as well, using
 // the Batch method of Session.

--- a/vendor/src/github.com/globalsign/mgo/session.go
+++ b/vendor/src/github.com/globalsign/mgo/session.go
@@ -3175,6 +3175,20 @@ func (c *Collection) CreateCustomCosmosDB(info *CosmosDBCollectionInfo) error {
 	return c.Database.Run(cmd, nil)
 }
 
+/*
+func (c *Collection) GetLastRequestStatistics() (charge uint, err error) {
+	var result bson.D
+
+	cmd := make(bson.D, 0, 4)
+	cmd = append(cmd, bson.DocElem{"getLastRequestStatistics", "1"})
+
+	err = c.Database.Run(cmd, &result)
+	m := result.Map()
+	charge = uint(math.Ceil(m["RequestCharge"].(float64)))
+
+	return charge, err
+}
+*/
 // Batch sets the batch size used when fetching documents from the database.
 // It's possible to change this setting on a per-session basis as well, using
 // the Batch method of Session.

--- a/vendor/src/github.com/globalsign/mgo/session.go
+++ b/vendor/src/github.com/globalsign/mgo/session.go
@@ -2855,8 +2855,8 @@ func (c *Collection) Insert(docs ...interface{}) error {
 }
 
 // Insert with the insert op directly (For performance)
-func (c *Collection) InsertRaw(op *PInsertOp) error {
-	_, err := c.writeOp(op.Iop, true)
+func (c *Collection) InsertWithOp(op *InsertOperation) error {
+	_, err := c.writeOp(op.Op, true)
 	return err
 }
 

--- a/vendor/src/github.com/globalsign/mgo/session.go
+++ b/vendor/src/github.com/globalsign/mgo/session.go
@@ -3181,7 +3181,7 @@ func (c *Collection) CreateCustomCosmosDB(info *CosmosDBCollectionInfo) error {
 	return c.Database.Run(cmd, nil)
 }
 
-func (c *Collection) GetLastRequestStatistics() (charge uint, err error) {
+func (c *Collection) GetLastRequestStatistics() (charge int64, err error) {
 	var result bson.D
 
 	cmd := make(bson.D, 0, 4)
@@ -3189,7 +3189,7 @@ func (c *Collection) GetLastRequestStatistics() (charge uint, err error) {
 
 	err = c.Database.Run(cmd, &result)
 	m := result.Map()
-	charge = uint(math.Ceil(m["RequestCharge"].(float64)))
+	charge = int64(math.Ceil(m["RequestCharge"].(float64)))
 
 	return charge, err
 }

--- a/vendor/src/github.com/globalsign/mgo/socket.go
+++ b/vendor/src/github.com/globalsign/mgo/socket.go
@@ -151,15 +151,14 @@ type replyOp struct {
 }
 
 // Expose insertOp as public member by wrapping it
-type PInsertOp struct {
-	Iop *insertOp
+type InsertOperation struct {
+	Op *insertOp
 }
 
-func NewInsertOp(collectionName string, docs ...interface{}) *PInsertOp {
-	op := new(PInsertOp)
-	op.Iop = &insertOp{collectionName, docs, 0}
-
-	return op
+func CreateInsertOp(collectionName string, docs ...interface{}) *InsertOperation {
+	return &InsertOperation{
+		&insertOp{collectionName, docs, 0},
+	}
 }
 
 type insertOp struct {

--- a/vendor/src/github.com/globalsign/mgo/socket.go
+++ b/vendor/src/github.com/globalsign/mgo/socket.go
@@ -150,6 +150,18 @@ type replyOp struct {
 	replyDocs int32
 }
 
+// Expose insertOp as public member by wrapping it
+type PInsertOp struct {
+	Iop *insertOp
+}
+
+func NewInsertOp(collectionName string, docs ...interface{}) *PInsertOp {
+	op := new(PInsertOp)
+	op.Iop = &insertOp{collectionName, docs, 0}
+
+	return op
+}
+
 type insertOp struct {
 	collection string        // "database.collection"
 	documents  []interface{} // One or more documents to insert


### PR DESCRIPTION
## Major changes
---
- New `HiringManager` which controls the hiring rate of new workers to help speed up ingestion when starting with a low worker count
   - Expose RU consumption on last operation, to give insight to `HiringManager`
   - Measure latency of insertion operation, to give insight to `HiringManager`
- Moved retry code out of `mgo` and into `CosmosDbInserter`


### Other changes
----
- [Performance] Expose `insertOp` publicly by wrapping it in `InsertOperation`, allowing the `CosmosDbInserter` to retry without having to re-create the the objects needed for insertion
