### PR TITLE
Update mongorestore with all major changes to mongoimport

### DIFF
--- a/common/cosmosdb/cosmoscollection.go
+++ b/common/cosmosdb/cosmoscollection.go
@@ -1,0 +1,30 @@
+package cosmosdb
+
+import (
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+)
+
+// The CosmosDBCollectionInfo type holds metadata about a CosmosDB collection.
+type CosmosDBCollectionInfo struct {
+	ShardKey   string
+	Throughput int
+}
+
+// CreateCustomCosmosDB explicitly creates the c collection for
+// Azure CosmosDB, allowing the specification of throughput and shard keys
+func CreateCustomCosmosDB(info CosmosDBCollectionInfo, c *mgo.Collection) error {
+	cmd := make(bson.D, 0, 4)
+	cmd = append(cmd, bson.DocElem{"customAction", "CreateCollection"})
+	cmd = append(cmd, bson.DocElem{"collection", c.Name})
+
+	//TODO: Validate the throughput range for Fixed & Unlimited collections
+	cmd = append(cmd, bson.DocElem{"offerThroughput", info.Throughput})
+
+	//TODO: Validate the shardkey to be in an acceptable format
+	if info.ShardKey != "" {
+		cmd = append(cmd, bson.DocElem{"shardKey", info.ShardKey})
+	}
+
+	return c.Database.Run(cmd, nil)
+}

--- a/common/cosmosdb/cosmosinserter.go
+++ b/common/cosmosdb/cosmosinserter.go
@@ -1,0 +1,73 @@
+package cosmosdb
+
+import (
+	"time"
+
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/mongodb/mongo-tools/common/log"
+)
+
+const (
+	CSV  = "csv"
+	TSV  = "tsv"
+	JSON = "json"
+)
+
+type CosmosDbInserter struct {
+	collection *mgo.Collection
+}
+
+func NewCosmosDbInserter(collection *mgo.Collection) *CosmosDbInserter {
+	return &CosmosDbInserter{
+		collection: collection,
+	}
+}
+
+func (ci *CosmosDbInserter) Insert(doc interface{}, manager *HiringManager, workerId int) error {
+	// Prevent the retry from re-creating the insertOp object again by explicitly storing it
+	insertOperation := mgo.CreateInsertOp(ci.collection.FullName, doc.(bson.D))
+	opDeadline := time.Now().Add(5 * time.Second)
+
+retry:
+	latency, err := ci.collection.InsertWithOp(insertOperation)
+	if err != nil {
+		if qerr, ok := err.(*mgo.QueryError); ok {
+			switch qerr.Code {
+
+			// TooManyRequest
+			case 16500:
+				manager.NotifyRateLimit()
+				//log.Logvf(log.Always, "We're overloading Cosmos DB; let's wait")
+				time.Sleep(5 * time.Millisecond)
+
+				if time.Now().After(opDeadline) {
+					log.Logv(log.Always, "Maximum throughput retry exceeded 5 seconds; moving on")
+				} else {
+					goto retry
+				}
+
+			// Malformed Request
+			case 9:
+				log.Logv(log.Always, "The request sent was malformed")
+
+			default:
+				log.Logvf(log.Always, "Unknown QueryError code: %s", err)
+			}
+		} else {
+			log.Logvf(log.Always, "Received something that is not a QueryError: %v", err)
+		}
+	} else {
+		if manager.CanNotify(workerId) {
+			insertCharge, _ := ci.collection.GetLastRequestStatistics()
+			manager.Notify(workerId, latency, insertCharge)
+		}
+	}
+	return err
+}
+
+// Flush is needed so that upserter implements flushInserter, but upserter
+// doesn't buffer anything so we don't need to do anything in Flush.
+func (ci *CosmosDbInserter) Flush() error {
+	return nil
+}

--- a/common/cosmosdb/hiringmanager.go
+++ b/common/cosmosdb/hiringmanager.go
@@ -1,0 +1,151 @@
+package cosmosdb
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mongodb/mongo-tools/common/log"
+)
+
+type AddWorkerAction func(h *HiringManager, a int)
+
+type HiringManager struct {
+	latencyRecords     []int64
+	consumptionRecords []int64
+
+	rateLimitCounter int64
+	workerCount      int
+	throughput       int
+
+	workerWg *sync.WaitGroup
+	recordWg *sync.WaitGroup
+	Action   AddWorkerAction
+}
+
+func NewHiringManager(defaultWorkers int, throughput int) *HiringManager {
+	return &HiringManager{
+		latencyRecords:     make([]int64, 0, defaultWorkers),
+		consumptionRecords: make([]int64, 0, defaultWorkers),
+		rateLimitCounter:   0,
+		workerCount:        0,
+		throughput:         throughput,
+		workerWg:           new(sync.WaitGroup),
+		recordWg:           new(sync.WaitGroup),
+		Action:             nil,
+	}
+}
+
+func (h *HiringManager) AwaitAllWorkers() {
+	h.workerWg.Wait()
+}
+
+func (h *HiringManager) CountWorkers() int {
+	return h.workerCount
+}
+
+func (h *HiringManager) CanNotify(workerId int) bool {
+	return atomic.LoadInt64(&h.latencyRecords[workerId]) == -1
+}
+
+func (h *HiringManager) Notify(workerId int, latency int64, charge int64) {
+	if latency < 0 {
+		return
+	}
+	defer h.recordWg.Done()
+	atomic.StoreInt64(&h.latencyRecords[workerId], latency)
+	atomic.StoreInt64(&h.consumptionRecords[workerId], charge)
+}
+
+func (h *HiringManager) Start(n int, autoScaleWorkers bool) {
+	for i := 0; i < n; i++ {
+		h.HireNewWorker()
+	}
+	if !autoScaleWorkers {
+		log.Logv(log.Info, "Auto Scaling of Insertion Workers is not enable in this run")
+		return
+	}
+	go func() {
+		sleepTime := 5 * time.Second
+
+		for {
+			time.Sleep(sleepTime)
+			/*if !imp.Alive() {
+				return
+			}*/
+
+			h.recordWg.Add(h.workerCount)
+			for i := 0; i < h.workerCount; i++ {
+				atomic.StoreInt64(&h.latencyRecords[i], -1)
+				atomic.StoreInt64(&h.consumptionRecords[i], -1)
+			}
+			h.recordWg.Wait()
+
+			var latencySum int64
+			var chargeSum int64
+			for i := 0; i < h.workerCount; i++ {
+				latencySum += atomic.LoadInt64(&h.latencyRecords[i])
+				chargeSum += atomic.LoadInt64(&h.consumptionRecords[i])
+			}
+			averageLatency := latencySum / int64(h.workerCount)
+			averageCharge := chargeSum / int64(h.workerCount)
+			log.Logvf(log.Info, "On average, insertions took %d (ns) and consumed %d RU", averageLatency, averageCharge)
+
+			amount := int(math.Ceil((float64(h.throughput) * float64(averageLatency) / 1000000.0) / float64(averageCharge)))
+			amountToHire := (amount - h.workerCount) / 2
+			log.Logvf(log.Info, "Target workers %d | Hiring %d", amount, amountToHire)
+			if amountToHire <= 0 || amountToHire > 100 || h.WasRecentlyRateLimited() {
+				break
+			}
+
+			for i := 0; i < amountToHire; i++ {
+				h.HireNewWorker()
+			}
+			log.Logvf(log.Info, "Manager thinks we can move faster; there are now %d workers", h.workerCount)
+			sleepTime = sleepTime + (3 * time.Second)
+		}
+
+		log.Logv(log.Info, "Hiring manager has stopped mass hiring; switching to single hire")
+
+		for {
+			time.Sleep(5 * time.Second)
+			/*if !imp.Alive() {
+				return
+			}*/
+			if h.WasRecentlyRateLimited() {
+				continue
+			}
+
+			h.HireNewWorker()
+			log.Logvf(log.Info, "Manager thinks we can move a bit faster; there are now %d workers", h.workerCount)
+		}
+	}()
+}
+
+func (h *HiringManager) HireNewWorker() {
+	h.latencyRecords = append(h.latencyRecords, 0)
+	h.consumptionRecords = append(h.consumptionRecords, 0)
+	newWorkerID := h.workerCount
+	h.workerCount++
+
+	h.workerWg.Add(1)
+	go func() {
+		defer h.workerWg.Done()
+		h.Action(h, newWorkerID)
+	}()
+}
+
+func (h *HiringManager) NotifyRateLimit() {
+	atomic.AddInt64(&h.rateLimitCounter, 1)
+}
+
+func (h *HiringManager) WasRecentlyRateLimited() bool {
+	limitCount := atomic.LoadInt64(&h.rateLimitCounter)
+	atomic.StoreInt64(&h.rateLimitCounter, 0)
+	if limitCount > 0 {
+		log.Logvf(log.Info, "There was %d `Request rate too large` responses, no extra workers are needed", limitCount)
+		return true
+	}
+	return false
+}

--- a/common/cosmosdb/util.go
+++ b/common/cosmosdb/util.go
@@ -1,0 +1,12 @@
+package cosmosdb
+
+import (
+	"time"
+
+	"github.com/mongodb/mongo-tools/common/log"
+)
+
+func BenchmarkTime(start time.Time, name string) {
+	elapsed := time.Since(start)
+	log.Logvf(log.Always, "%s took %s", name, elapsed)
+}

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -98,6 +98,18 @@ type General struct {
 
 	MaxProcs   int    `long:"numThreads" hidden:"true"`
 	Failpoints string `long:"failpoints" hidden:"true"`
+
+	// Indicate the amount of throughput to set the Azure CosmosDB collections to
+	Throughput int `long:"throughput" value-name:"<number>" default:"10000" description:"Throughput to set on a CosmosDB collection"`
+
+	// Specify the Shard key for Azure CosmosDB to perform sharding with
+	ShardKey string `long:"shardKey" value-name:"<field>" description:"Shard key for CosmosDB; specifying this key will set the collection size to be 'Unlimited' instead of 'Fixed', which also raises the maximum RU from 10k to 50k"`
+
+	// For testing purposes; be later removed
+	ImportCycle int `long:"importCycle" value-name:"<number>" default:"1" hidden:"true" description:"Repeat the import cycle <num> amount of times"`
+
+	// Flag for adaptive insertion worker scaling
+	AutoScaleWorkers bool `long:"autoScaleWorkers" default:"false" description:"Enable the scale up of Insertion workers"`
 }
 
 // Struct holding verbosity-related options

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -58,7 +58,7 @@ func main() {
 
 	// verify uri options and log them
 	opts.URI.LogUnsupportedOptions()
-	for i := 0; i < ingestOpts.ImportCycle; i++ {
+	for i := 0; i < opts.ImportCycle; i++ {
 		log.Logvf(log.Info, "Import cycle: %d", i)
 		importCycle(opts, inputOpts, ingestOpts, args)
 	}

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/mongodb/mongo-tools/common/cosmosdb"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
@@ -19,11 +20,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/mongodb/mongo-tools/mongoimport"
 )
-
-func timeTrack(start time.Time, name string) {
-	elapsed := time.Since(start)
-	log.Logvf(log.Always, "%s took %s", name, elapsed)
-}
 
 func main() {
 	// initialize command-line opts
@@ -65,7 +61,7 @@ func main() {
 }
 
 func importCycle(opts *options.ToolOptions, inputOpts *mongoimport.InputOptions, ingestOpts *mongoimport.IngestOptions, args []string) {
-	defer timeTrack(time.Now(), "Import")
+	defer cosmosdb.BenchmarkTime(time.Now(), "Import")
 	// create a session provider to connect to the db
 	sessionProvider, err := db.NewSessionProvider(*opts)
 	if err != nil {

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -8,11 +8,11 @@
 package mongoimport
 
 import (
-	"math"
 	"runtime"
 
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/mongodb/mongo-tools/common/cosmosdb"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -427,147 +426,6 @@ func (imp *MongoImport) importDocuments(inputReader InputReader) (numImported ui
 	return insertionCount, e1
 }
 
-type AddWorkerAction func(h *HiringManager, a int)
-
-type HiringManager struct {
-	latencyRecords     []int64
-	consumptionRecords []int64
-
-	rateLimitCounter int64
-	workerCount      int
-	throughput       int
-
-	workerWg *sync.WaitGroup
-	recordWg *sync.WaitGroup
-	Action   AddWorkerAction
-}
-
-func NewHiringManager(defaultWorkers int, throughput int) *HiringManager {
-	return &HiringManager{
-		latencyRecords:     make([]int64, 0, defaultWorkers),
-		consumptionRecords: make([]int64, 0, defaultWorkers),
-		rateLimitCounter:   0,
-		workerCount:        0,
-		throughput:         throughput,
-		workerWg:           new(sync.WaitGroup),
-		recordWg:           new(sync.WaitGroup),
-		Action:             nil,
-	}
-}
-
-func (h *HiringManager) AwaitAllWorkers() {
-	h.workerWg.Wait()
-}
-
-func (h *HiringManager) CountWorkers() int {
-	return h.workerCount
-}
-
-func (h *HiringManager) CanNotify(workerId int) bool {
-	return atomic.LoadInt64(&h.latencyRecords[workerId]) == -1
-}
-
-func (h *HiringManager) Notify(workerId int, latency int64, charge int64) {
-	if latency < 0 {
-		return
-	}
-	defer h.recordWg.Done()
-	atomic.StoreInt64(&h.latencyRecords[workerId], latency)
-	atomic.StoreInt64(&h.consumptionRecords[workerId], charge)
-}
-
-func (h *HiringManager) Start(n int, imp *MongoImport) {
-	for i := 0; i < n; i++ {
-		h.HireNewWorker()
-	}
-	if !imp.IngestOptions.AutoScaleWorkers {
-		log.Logv(log.Info, "Auto Scaling of Insertion Workers is not enable in this run")
-		return
-	}
-	go func() {
-		sleepTime := 5 * time.Second
-
-		for {
-			time.Sleep(sleepTime)
-			if !imp.Alive() {
-				return
-			}
-
-			h.recordWg.Add(h.workerCount)
-			for i := 0; i < h.workerCount; i++ {
-				atomic.StoreInt64(&h.latencyRecords[i], -1)
-				atomic.StoreInt64(&h.consumptionRecords[i], -1)
-			}
-			h.recordWg.Wait()
-
-			var latencySum int64
-			var chargeSum int64
-			for i := 0; i < h.workerCount; i++ {
-				latencySum += atomic.LoadInt64(&h.latencyRecords[i])
-				chargeSum += atomic.LoadInt64(&h.consumptionRecords[i])
-			}
-			averageLatency := latencySum / int64(h.workerCount)
-			averageCharge := chargeSum / int64(h.workerCount)
-			log.Logvf(log.Info, "On average, insertions took %d (ns) and consumed %d RU", averageLatency, averageCharge)
-
-			amount := int(math.Ceil((float64(h.throughput) * float64(averageLatency) / 1000000.0) / float64(averageCharge)))
-			amountToHire := (amount - h.workerCount) / 2
-			log.Logvf(log.Info, "Target workers %d | Hiring %d", amount, amountToHire)
-			if amountToHire <= 0 || amountToHire > 100 || h.WasRecentlyRateLimited() {
-				break
-			}
-
-			for i := 0; i < amountToHire; i++ {
-				h.HireNewWorker()
-			}
-			log.Logvf(log.Info, "Manager thinks we can move faster; there are now %d workers", h.workerCount)
-			sleepTime = sleepTime + (3 * time.Second)
-		}
-
-		log.Logv(log.Info, "Hiring manager has stopped mass hiring; switching to single hire")
-
-		for {
-			time.Sleep(5 * time.Second)
-			if !imp.Alive() {
-				return
-			}
-			if h.WasRecentlyRateLimited() {
-				continue
-			}
-
-			h.HireNewWorker()
-			log.Logvf(log.Info, "Manager thinks we can move a bit faster; there are now %d workers", h.workerCount)
-		}
-	}()
-}
-
-func (h *HiringManager) HireNewWorker() {
-	h.latencyRecords = append(h.latencyRecords, 0)
-	h.consumptionRecords = append(h.consumptionRecords, 0)
-	newWorkerID := h.workerCount
-	h.workerCount++
-
-	h.workerWg.Add(1)
-	go func() {
-		defer h.workerWg.Done()
-		h.Action(h, newWorkerID)
-	}()
-}
-
-func (h *HiringManager) NotifyRateLimit() {
-	atomic.AddInt64(&h.rateLimitCounter, 1)
-}
-
-func (h *HiringManager) WasRecentlyRateLimited() bool {
-	limitCount := atomic.LoadInt64(&h.rateLimitCounter)
-	atomic.StoreInt64(&h.rateLimitCounter, 0)
-	if limitCount > 0 {
-		log.Logvf(log.Info, "There was %d `Request rate too large` responses, no extra workers are needed", limitCount)
-		return true
-	}
-	return false
-}
-
 // ingestDocuments accepts a channel from which it reads documents to be inserted
 // into the target collection. It spreads the insert/upsert workload across one
 // or more workers.
@@ -578,14 +436,15 @@ func (imp *MongoImport) ingestDocuments(readDocs chan bson.D) (retErr error) {
 	numInsertionWorkers := imp.IngestOptions.NumInsertionWorkers
 	log.Logvf(log.Info, "Assigning %d insertion workers", numInsertionWorkers)
 
-	manager := NewHiringManager(numInsertionWorkers, imp.IngestOptions.Throughput)
-	manager.Action = AddWorkerAction(func(hm *HiringManager, workerId int) {
+	manager := cosmosdb.NewHiringManager(numInsertionWorkers, imp.IngestOptions.Throughput)
+	manager.Action = cosmosdb.AddWorkerAction(func(hm *cosmosdb.HiringManager, workerId int) {
 		err := imp.runInsertionWorker(readDocs, hm, workerId)
 		if err != nil {
 			imp.Kill(err)
 		}
 	})
-	manager.Start(numInsertionWorkers, imp)
+
+	manager.Start(numInsertionWorkers, imp.IngestOptions.AutoScaleWorkers)
 	manager.AwaitAllWorkers()
 	return
 }
@@ -618,7 +477,7 @@ type flushInserter interface {
 
 // runInsertionWorker is a helper to InsertDocuments - it reads document off
 // the read channel and prepares then in batches for insertion into the databas
-func (imp *MongoImport) runInsertionWorker(readDocs chan bson.D, manager *HiringManager, workerId int) (err error) {
+func (imp *MongoImport) runInsertionWorker(readDocs chan bson.D, manager *cosmosdb.HiringManager, workerId int) (err error) {
 	session, err := imp.SessionProvider.GetSession()
 	if err != nil {
 		return fmt.Errorf("error connecting to mongod: %v", err)
@@ -628,7 +487,7 @@ func (imp *MongoImport) runInsertionWorker(readDocs chan bson.D, manager *Hiring
 		return fmt.Errorf("error configuring session: %v", err)
 	}
 	collection := session.DB(imp.ToolOptions.DB).C(imp.ToolOptions.Collection)
-	inserter := imp.newCosmosDbInserter(collection)
+	inserter := cosmosdb.NewCosmosDbInserter(collection)
 
 readLoop:
 	for {
@@ -662,66 +521,6 @@ readLoop:
 		}
 	}
 	return filterIngestError(imp.IngestOptions.StopOnError, err)
-}
-
-type CosmosDbInserter struct {
-	imp        *MongoImport
-	collection *mgo.Collection
-}
-
-func (imp *MongoImport) newCosmosDbInserter(collection *mgo.Collection) *CosmosDbInserter {
-	return &CosmosDbInserter{
-		imp:        imp,
-		collection: collection,
-	}
-}
-
-func (ci *CosmosDbInserter) Insert(doc interface{}, manager *HiringManager, workerId int) error {
-	// Prevent the retry from re-creating the insertOp object again by explicitly storing it
-	insertOperation := mgo.CreateInsertOp(ci.collection.FullName, doc.(bson.D))
-	opDeadline := time.Now().Add(5 * time.Second)
-
-retry:
-	latency, err := ci.collection.InsertWithOp(insertOperation)
-	if err != nil {
-		if qerr, ok := err.(*mgo.QueryError); ok {
-			switch qerr.Code {
-
-			// TooManyRequest
-			case 16500:
-				manager.NotifyRateLimit()
-				//log.Logvf(log.Always, "We're overloading Cosmos DB; let's wait")
-				time.Sleep(5 * time.Millisecond)
-
-				if time.Now().After(opDeadline) {
-					log.Logv(log.Always, "Maximum throughput retry exceeded 5 seconds; moving on")
-				} else {
-					goto retry
-				}
-
-			// Malformed Request
-			case 9:
-				log.Logv(log.Always, "The request sent was malformed")
-
-			default:
-				log.Logvf(log.Always, "Unknown QueryError code: %s", err)
-			}
-		} else {
-			log.Logvf(log.Always, "Received something that is not a QueryError: %v", err)
-		}
-	} else {
-		if manager.CanNotify(workerId) {
-			insertCharge, _ := ci.collection.GetLastRequestStatistics()
-			manager.Notify(workerId, latency, insertCharge)
-		}
-	}
-	return err
-}
-
-// Flush is needed so that upserter implements flushInserter, but upserter
-// doesn't buffer anything so we don't need to do anything in Flush.
-func (ci *CosmosDbInserter) Flush() error {
-	return nil
 }
 
 type upserter struct {

--- a/mongoimport/options.go
+++ b/mongoimport/options.go
@@ -86,18 +86,6 @@ type IngestOptions struct {
 	NumDecodingWorkers int `long:"numDecodingWorkers" default:"0" hidden:"true"`
 
 	BulkBufferSize int `long:"batchSize" value-name:"<number>" default:"1" hidden:"true"`
-
-	// Indicate the amount of throughput to set the Azure CosmosDB collections to
-	Throughput int `long:"throughput" value-name:"<number>" default:"10000" description:"Throughput to set on a CosmosDB collection"`
-
-	// Specify the Shard key for Azure CosmosDB to perform sharding with
-	ShardKey string `long:"shardKey" value-name:"<field>" description:"Shard key for CosmosDB; specifying this key will set the collection size to be 'Unlimited' instead of 'Fixed', which also raises the maximum RU from 10k to 50k"`
-
-	// For testing purposes; be later removed
-	ImportCycle int `long:"importCycle" value-name:"<number>" default:"1" hidden:"true" description:"Repeat the import cycle <num> amount of times"`
-
-	// Flag for adaptive insertion worker scaling
-	AutoScaleWorkers bool `long:"autoScaleWorkers" default:"false" description:"Enable the scale up of Insertion workers"`
 }
 
 // Name returns a description of the IngestOptions struct.

--- a/mongorestore/main/mongorestore.go
+++ b/mongorestore/main/mongorestore.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/mongodb/mongo-tools/common/cosmosdb"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/options"
@@ -99,6 +100,7 @@ func main() {
 
 	finishedChan := signals.HandleWithInterrupt(restore.HandleInterrupt)
 	defer close(finishedChan)
+	defer cosmosdb.BenchmarkTime(time.Now(), "Restore")
 
 	if err = restore.Restore(); err != nil {
 		log.Logvf(log.Always, "Failed: %v", err)

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -10,6 +10,8 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	"github.com/mongodb/mongo-tools/common"
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
@@ -17,8 +19,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/json"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/util"
-	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
 )
 
 // Specially treated restore collection types.

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -16,6 +16,8 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	"github.com/mongodb/mongo-tools/common/archive"
 	"github.com/mongodb/mongo-tools/common/auth"
 	"github.com/mongodb/mongo-tools/common/db"
@@ -25,8 +27,6 @@ import (
 	"github.com/mongodb/mongo-tools/common/progress"
 	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/mongodb/mongo-tools/mongorestore/ns"
-	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
 )
 
 // MongoRestore is a container for the user-specified options and

--- a/vendor/src/github.com/globalsign/mgo/bulk.go
+++ b/vendor/src/github.com/globalsign/mgo/bulk.go
@@ -324,7 +324,7 @@ func (b *Bulk) runInsert(action *bulkAction, result *BulkResult, berr *BulkError
 	if !b.ordered {
 		op.flags = 1 // ContinueOnError
 	}
-	lerr, err := b.c.RetryableWriteOp(op, b.ordered)
+	lerr, err := b.c.writeOp(op, b.ordered)
 	return b.checkSuccess(action, berr, lerr, err)
 }
 

--- a/vendor/src/github.com/globalsign/mgo/session.go
+++ b/vendor/src/github.com/globalsign/mgo/session.go
@@ -45,7 +45,6 @@ import (
 	"time"
 
 	"github.com/globalsign/mgo/bson"
-	logger "github.com/mongodb/mongo-tools/common/log"
 )
 
 // Mode read preference mode. See Eventual, Monotonic and Strong for details

--- a/vendor/src/github.com/globalsign/mgo/session.go
+++ b/vendor/src/github.com/globalsign/mgo/session.go
@@ -5160,43 +5160,6 @@ func (r *writeCmdResult) BulkErrorCases() []BulkErrorCase {
 	return ecases
 }
 
-// RetryableWriteOp will retry write operations for a time period
-func (c *Collection) RetryableWriteOp(op interface{}, ordered bool) (lerr *LastError, err error) {
-	opStartTime := time.Now()
-	opDeadline := opStartTime.Add(5 * time.Second)
-
-retry:
-	lerr, err = c.writeOp(op, ordered)
-	if err != nil {
-		if qerr, ok := err.(*QueryError); ok {
-			switch qerr.Code {
-
-			// TooManyRequest
-			case 16500:
-				//logger.Logvf(logger.Always, "We're overloading Cosmos DB; let's wait",)
-				time.Sleep(5 * time.Millisecond)
-
-				if time.Now().After(opDeadline) {
-					logger.Logv(logger.Always, "Maximum throughput retry exceeded 5 seconds; moving on")
-				} else {
-					goto retry
-				}
-
-			// Malformed Request
-			case 9:
-				logger.Logv(logger.Always, "The request sent was malformed")
-
-			default:
-				logger.Logvf(logger.Always, "Unknown err case: %s", err)
-			}
-		} else {
-			logger.Logvf(logger.Always, "Received something that is not a QueryError: %v", err)
-		}
-		return lerr, err
-	}
-	return nil, nil
-}
-
 // writeOp runs the given modifying operation, potentially followed up
 // by a getLastError command in case the session is in safe mode.  The
 // LastError result is made available in lerr, and if lerr.Err is set it


### PR DESCRIPTION
## Major changes
---
- Refactored most shared Cosmos DB logic into the `common/cosmosdb` folder
- Refactored all shared flags (`--autoScaleWorker`, `--throughput`, `--shardKey`, ...etc) into ToolOptions

### Minor changes
---
- Removed remnants of old retry code inside `mgo`
- Removed logger from `mgo/session`
- Moved function execution benchmark into common