### PR TITLE
Improve retry logic and backup channel

### DIFF
--- a/common/cosmosdb/cosmoscollection.go
+++ b/common/cosmosdb/cosmoscollection.go
@@ -40,7 +40,8 @@ func VerifyDocumentCount(collection *mgo.Collection, expectedCount uint64) error
 	countOpDeadline := time.Now().Add(5 * time.Second)
 	for {
 		if time.Now().After(countOpDeadline) {
-			return fmt.Errorf("Time limit for counting has exceeded; some documents may have been lost during the restore")
+			log.Logv(log.Always, "Time limit for counting has exceeded; some documents may have been lost during the ingestion into Cosmos DB")
+			return fmt.Errorf("Time limit exceeded")
 		}
 
 		currentCount, countErr := collection.Count()

--- a/common/cosmosdb/cosmoscollection.go
+++ b/common/cosmosdb/cosmoscollection.go
@@ -1,8 +1,12 @@
 package cosmosdb
 
 import (
+	"os"
+	"time"
+
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/mongodb/mongo-tools/common/log"
 )
 
 // The CosmosDBCollectionInfo type holds metadata about a CosmosDB collection.
@@ -27,4 +31,31 @@ func CreateCustomCosmosDB(info CosmosDBCollectionInfo, c *mgo.Collection) error 
 	}
 
 	return c.Database.Run(cmd, nil)
+}
+
+// VerifyDocumentCount periodically sends a count operation until either the resulting count matches
+// the expected count or the timeout occurs; this is essential for sharded Cosmos DB collection as there
+// is a small chance the master does not have the latest count.
+func VerifyDocumentCount(collection *mgo.Collection, expectedCount uint64) bool {
+	countOpDeadline := time.Now().Add(5 * time.Second)
+	for {
+		if time.Now().After(countOpDeadline) {
+			log.Logv(log.Always, "Time limit for counting has exceeded; some documents may have been lost during the restore")
+			os.Exit(123)
+		}
+
+		currentCount, countErr := collection.Count()
+
+		if countErr != nil {
+			return false
+		}
+
+		if uint64(currentCount) != expectedCount {
+			log.Logvf(log.Always, "CosmosDB only reported %v documents while we ingested %v documents, let's try counting again...", currentCount, expectedCount)
+			time.Sleep(500 * time.Millisecond)
+		} else {
+			log.Logvf(log.Always, "%s has a total of %d documents in Azure Cosmos DB", collection.Name, currentCount)
+			return true
+		}
+	}
 }

--- a/common/cosmosdb/cosmosinserter.go
+++ b/common/cosmosdb/cosmosinserter.go
@@ -65,8 +65,6 @@ retry:
 			default:
 				log.Logvf(log.Always, "An unknown QuerryError occured: %d - %s", qerr.Code, err)
 			}
-		} else {
-			log.Logvf(log.Always, "An error occured: %v", err)
 		}
 	} else {
 		if manager.CanNotify(workerId) {

--- a/common/cosmosdb/hiringmanager.go
+++ b/common/cosmosdb/hiringmanager.go
@@ -38,6 +38,7 @@ func NewHiringManager(defaultWorkers int, throughput int) *HiringManager {
 
 func (h *HiringManager) AwaitAllWorkers() {
 	h.workerWg.Wait()
+	log.Logv(log.Info, "All workers have finished")
 }
 
 func (h *HiringManager) CountWorkers() int {
@@ -137,7 +138,7 @@ func (h *HiringManager) HireNewWorker() {
 	go func() {
 		defer h.workerWg.Done()
 		if err := h.AddWorkerAction(h, newWorkerID); err != nil {
-			log.Logvf(log.Always, "Worker %d exiting due to an error: %v", err)
+			log.Logvf(log.Always, "Worker %d exiting due to an error: %v", newWorkerID, err)
 		}
 	}()
 }

--- a/common/cosmosdb/hiringmanager.go
+++ b/common/cosmosdb/hiringmanager.go
@@ -61,12 +61,12 @@ func (h *HiringManager) Notify(workerId int, latency int64, charge int64) {
 }
 
 // Start launches the manager routine which periodically checks whether it can add new workers to speed up the ingestion task
-func (h *HiringManager) Start(n int, autoScaleWorkers bool) {
+func (h *HiringManager) Start(n int, disableWorkerScaling bool) {
 	for i := 0; i < n; i++ {
 		h.HireNewWorker()
 	}
-	if !autoScaleWorkers {
-		log.Logv(log.Info, "Auto Scaling of Insertion Workers is not enable in this run")
+	if disableWorkerScaling {
+		log.Logv(log.Always, "Auto Scaling of Insertion Workers is disabled in this run")
 		return
 	}
 	go func() {

--- a/common/cosmosdb/hiringmanager.go
+++ b/common/cosmosdb/hiringmanager.go
@@ -94,7 +94,7 @@ func (h *HiringManager) Start(n int, autoScaleWorkers bool) {
 
 			amount := int(math.Ceil((float64(h.throughput) * float64(averageLatency) / 1000000.0) / float64(averageCharge)))
 			amountToHire := (amount - h.workerCount) / 2
-			log.Logvf(log.Info, "Target workers %d | Hiring %d", amount, amountToHire)
+			log.Logvf(log.Info, "Manager wants a total of workers %d; thus an additional %d workers will be hired", amount, amountToHire)
 			if amountToHire <= 0 || amountToHire > 100 || h.WasRecentlyRateLimited() {
 				break
 			}
@@ -102,18 +102,18 @@ func (h *HiringManager) Start(n int, autoScaleWorkers bool) {
 			for i := 0; i < amountToHire; i++ {
 				h.HireNewWorker()
 			}
-			log.Logvf(log.Info, "Manager thinks we can move faster; there are now %d workers", h.workerCount)
+			log.Logvf(log.Info, "There are now a total of %d workers", h.workerCount)
 			sleepTime = sleepTime + (3 * time.Second)
 		}
 
-		log.Logv(log.Info, "Hiring manager has stopped mass hiring; switching to single hire")
+		log.Logv(log.Info, "Hiring manager has stopped mass hiring; switching to single hires")
 
 		for {
 			// The Hiring manager is vulnerable to sudden changes, need further work on this.
-			time.Sleep(5 * time.Second)
+			time.Sleep(10 * time.Second)
 
 			if h.WasRecentlyRateLimited() {
-				time.Sleep(10 * time.Second)
+				time.Sleep(30 * time.Second)
 				continue
 			}
 

--- a/common/cosmosdb/util.go
+++ b/common/cosmosdb/util.go
@@ -1,12 +1,25 @@
 package cosmosdb
 
 import (
+	"fmt"
+	"io"
 	"time"
 
+	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 )
 
 func BenchmarkTime(start time.Time, name string) {
 	elapsed := time.Since(start)
 	log.Logvf(log.Always, "%s took %s", name, elapsed)
+}
+
+func FilterUnrecoverableErrors(stopOnError bool, err error) error {
+	if err.Error() == io.EOF.Error() {
+		return fmt.Errorf(db.ErrLostConnection)
+	}
+	if stopOnError || db.IsConnectionError(err) {
+		return err
+	}
+	return nil
 }

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -109,7 +109,7 @@ type General struct {
 	ImportCycle int `long:"importCycle" value-name:"<number>" default:"1" hidden:"true" description:"Repeat the import cycle <num> amount of times"`
 
 	// Flag for adaptive insertion worker scaling
-	AutoScaleWorkers bool `long:"autoScaleWorkers" default:"false" description:"Enable the scale up of Insertion workers"`
+	DisableWorkerScaling bool `long:"disableWorkerScaling" default:"false" description:"Disable the scale up of Insertion workers"`
 }
 
 // Struct holding verbosity-related options

--- a/mongoimport/common.go
+++ b/mongoimport/common.go
@@ -248,8 +248,7 @@ func filterIngestError(stopOnError bool, err error) error {
 	if stopOnError || db.IsConnectionError(err) {
 		return err
 	}
-	//log.Logvf(log.Always, "error inserting documents: %v", err)
-	return nil
+	return err
 }
 
 // removeBlankFields takes document and returns a new copy in which

--- a/mongoimport/main/mongoimport.go
+++ b/mongoimport/main/mongoimport.go
@@ -54,13 +54,6 @@ func main() {
 
 	// verify uri options and log them
 	opts.URI.LogUnsupportedOptions()
-	for i := 0; i < opts.ImportCycle; i++ {
-		log.Logvf(log.Info, "Import cycle: %d", i)
-		importCycle(opts, inputOpts, ingestOpts, args)
-	}
-}
-
-func importCycle(opts *options.ToolOptions, inputOpts *mongoimport.InputOptions, ingestOpts *mongoimport.IngestOptions, args []string) {
 	defer cosmosdb.BenchmarkTime(time.Now(), "Import")
 	// create a session provider to connect to the db
 	sessionProvider, err := db.NewSessionProvider(*opts)
@@ -98,9 +91,4 @@ func importCycle(opts *options.ToolOptions, inputOpts *mongoimport.InputOptions,
 	if err != nil {
 		os.Exit(util.ExitError)
 	}
-
-	if err := m.CountDocumentsInCosmosDb(); err != nil {
-		log.Logvf(log.Always, "Unable to count the documents in the imported collection: %v", err)
-	}
-
 }

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -475,7 +475,7 @@ func (imp *MongoImport) ingestDocuments(readDocs chan bson.D) (retErr error) {
 			}
 		}
 	}
-	imp.CountDocumentsInCosmosDb()
+	retErr = imp.CountDocumentsInCosmosDb()
 	return
 }
 

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -440,7 +440,7 @@ func (imp *MongoImport) ingestDocuments(readDocs chan bson.D) (retErr error) {
 		}
 	})
 
-	manager.Start(numInsertionWorkers, imp.ToolOptions.General.AutoScaleWorkers)
+	manager.Start(numInsertionWorkers, imp.ToolOptions.General.DisableWorkerScaling)
 	manager.AwaitAllWorkers()
 	close(backupDocChan)
 	if len(backupDocChan) != 0 {

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -8,6 +8,8 @@
 package mongoimport
 
 import (
+	"time"
+
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/mongodb/mongo-tools/common/cosmosdb"
@@ -459,26 +461,12 @@ func (imp *MongoImport) ingestDocuments(readDocs chan bson.D) (retErr error) {
 		collection := session.DB(imp.ToolOptions.DB).C(imp.ToolOptions.Collection)
 		inserter := cosmosdb.NewCosmosDbInserter(collection)
 
-	backupLoop:
-		for {
-			select {
-			case document, alive := <-backupDocChan:
-				if !alive {
-					break backupLoop
+		for doc := range backupDocChan {
+			atomic.AddUint64(&imp.insertionCount, 1)
+			if err := inserter.Insert(doc, manager, 1); err != nil {
+				if err = cosmosdb.FilterUnrecoverableErrors(imp.IngestOptions.StopOnError, err); err != nil {
+					return err
 				}
-				if err = inserter.Insert(document, manager, 1); err != nil {
-					if err.Error() == io.EOF.Error() {
-						return fmt.Errorf(db.ErrLostConnection)
-					}
-					if imp.IngestOptions.StopOnError || db.IsConnectionError(err) {
-						return err
-					}
-					continue
-				}
-				atomic.AddUint64(&imp.insertionCount, 1)
-
-			case <-imp.Dying():
-				return nil
 			}
 		}
 	}
@@ -526,27 +514,36 @@ func (imp *MongoImport) runInsertionWorker(readDocs chan bson.D, backupDocChan c
 	collection := session.DB(imp.ToolOptions.DB).C(imp.ToolOptions.Collection)
 	inserter := cosmosdb.NewCosmosDbInserter(collection)
 
-readLoop:
 	for {
 		select {
-		case document, alive := <-readDocs:
-			if !alive {
-				break readLoop
-			}
-			if err = inserter.Insert(document, manager, workerId); err != nil {
-				backupDocChan <- document
-				if err.Error() == io.EOF.Error() {
-					return fmt.Errorf(db.ErrLostConnection)
-				}
-				if imp.IngestOptions.StopOnError || db.IsConnectionError(err) {
+		case backupDoc := <-backupDocChan:
+			log.Logvf(log.Info, "Worker %d picked up a document from the backup channel", workerId)
+			if err := inserter.Insert(backupDoc, manager, workerId); err != nil {
+				if err = cosmosdb.FilterUnrecoverableErrors(imp.IngestOptions.StopOnError, err); err != nil {
 					return err
 				}
 			}
-			atomic.AddUint64(&imp.insertionCount, 1)
 
-		case <-imp.Dying():
-			return nil
+		default:
+			document, alive := <-readDocs
+			if !alive {
+				log.Logvf(log.Info, "Worker %d has finished ingesting documents", workerId)
+				return nil
+			}
+			if err := inserter.Insert(document, manager, workerId); err != nil {
+				log.Logvf(log.Info, "Worker %d is backing up a document due to an error: %v", workerId, err)
+				backupDocChan <- document
+
+				if err = cosmosdb.FilterUnrecoverableErrors(imp.IngestOptions.StopOnError, err); err != nil {
+					return err
+				}
+
+				log.Logvf(log.Info, "Worker %d is able to recover from the error and go back in action", workerId)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
 		}
+		atomic.AddUint64(&imp.insertionCount, 1)
 	}
 
 	return nil

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -378,7 +378,9 @@ func (restore *MongoRestore) RestoreCollectionToDB(dbName, colName string,
 	s := session.Copy()
 	defer s.Close()
 	coll := collection.With(s)
-	cosmosdb.VerifyDocumentCount(coll, uint64(documentCount))
+	if err = cosmosdb.VerifyDocumentCount(coll, uint64(documentCount)); err != nil {
+		return int64(0), err
+	}
 
 	if err = bsonSource.Err(); err != nil {
 		return int64(0), fmt.Errorf("reading bson input: %v", err)

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -8,7 +8,6 @@ package mongorestore
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"strings"
 	"time"
@@ -291,7 +290,6 @@ func (restore *MongoRestore) RestoreCollectionToDB(dbName, colName string,
 
 	docChan := make(chan bson.Raw, insertBufferFactor)
 	backupDocChan := make(chan bson.Raw, insertBufferFactor*100)
-	resultChan := make(chan error, maxInsertWorkers)
 
 	// stream documents for this collection on docChan
 	go func() {
@@ -321,26 +319,33 @@ func (restore *MongoRestore) RestoreCollectionToDB(dbName, colName string,
 		coll := collection.With(s)
 		inserter := cosmosdb.NewCosmosDbInserter(coll)
 
-		for rawDoc := range docChan {
+		for {
 			select {
-			case <-restore.termChan:
-				return fmt.Errorf("Worker %d recieved termination signal, stopping now", workerId)
-
-			default:
-				if restore.objCheck {
-					if err := bson.Unmarshal(rawDoc.Data, &bson.D{}); err != nil {
-						return fmt.Errorf("invalid object: %v", err)
-					}
-				}
-
-				if err := inserter.Insert(rawDoc, hm, workerId); err != nil {
-					backupDocChan <- rawDoc
-					if err.Error() == io.EOF.Error() {
-						return fmt.Errorf(db.ErrLostConnection)
-					}
-					if restore.OutputOptions.StopOnError || db.IsConnectionError(err) {
+			case backupDoc := <-backupDocChan:
+				log.Logvf(log.Info, "Worker %d picked up a document from the backup channel", workerId)
+				if err := inserter.Insert(backupDoc, hm, workerId); err != nil {
+					if err = cosmosdb.FilterUnrecoverableErrors(restore.OutputOptions.StopOnError, err); err != nil {
 						return err
 					}
+				}
+			default:
+				document, alive := <-docChan
+				if !alive {
+					log.Logvf(log.Info, "Worker %d has finished ingesting documents", workerId)
+					return nil
+				}
+
+				if err := inserter.Insert(document, hm, workerId); err != nil {
+					log.Logvf(log.Info, "Worker %d is backing up a document due to an error: %v", workerId, err)
+					backupDocChan <- document
+
+					if err = cosmosdb.FilterUnrecoverableErrors(restore.OutputOptions.StopOnError, err); err != nil {
+						return err
+					}
+
+					log.Logvf(log.Info, "Worker %d is able to recover from the error and go back in action", workerId)
+					time.Sleep(100 * time.Millisecond)
+					continue
 				}
 			}
 			watchProgressor.Set(file.Pos())
@@ -362,22 +367,10 @@ func (restore *MongoRestore) RestoreCollectionToDB(dbName, colName string,
 		inserter := cosmosdb.NewCosmosDbInserter(coll)
 
 		for doc := range backupDocChan {
-			if restore.objCheck {
-				err := bson.Unmarshal(doc.Data, &bson.D{})
-				if err != nil {
-					resultChan <- fmt.Errorf("backup: invalid object: %v", err)
-					break
-				}
-			}
-
 			if err := inserter.Insert(doc, manager, 1); err != nil {
-				if err.Error() == io.EOF.Error() {
-					return 0, fmt.Errorf(db.ErrLostConnection)
-				}
-				if restore.OutputOptions.StopOnError || db.IsConnectionError(err) {
+				if err = cosmosdb.FilterUnrecoverableErrors(restore.OutputOptions.StopOnError, err); err != nil {
 					return 0, err
 				}
-				continue
 			}
 		}
 	}

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -346,7 +346,7 @@ func (restore *MongoRestore) RestoreCollectionToDB(dbName, colName string,
 		}
 	})
 
-	manager.Start(maxInsertWorkers, restore.ToolOptions.General.AutoScaleWorkers)
+	manager.Start(maxInsertWorkers, restore.ToolOptions.General.DisableWorkerScaling)
 	manager.AwaitAllWorkers()
 
 	close(backupDocChan)


### PR DESCRIPTION
### Major Changes
---
- Fix issue with socket not re-connecting upon error
- Enable worker scale up by default; use `--disableWorkerScaling` to turn it off
- Update mongoimport and mongorestore to both allow workers to collection from the backup channel during normal ingestion
- Retry count operation to give the master node some time to update its count

#### Other Changes
---
- Remove `--autoScaleWorkers` flag since worker scaling is enable by default