### PR TITLE
[Mitigation] - Temporary removal of document count check

### DIFF
--- a/common/cosmosdb/cosmoscollection.go
+++ b/common/cosmosdb/cosmoscollection.go
@@ -69,6 +69,15 @@ func VerifyDocumentCount(collection *mgo.Collection, expectedCount uint64) error
 	}
 }
 
+func GetDocumentCount(collection *mgo.Collection) error {
+	currentCount, countErr := collection.Count()
+	if countErr != nil {
+		return countErr
+	}
+	log.Logvf(log.Always, "%s has a total of %d documents in Azure Cosmos DB", collection.Name, currentCount)
+	return nil
+}
+
 func ValidateSizeRequirement(shardKey string, fileSize int64, ignoreSizeWarning bool) error {
 	log.Logvf(log.Info, "File size is: %d", fileSize)
 	if shardKey == "" {

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -664,7 +664,9 @@ func (imp *MongoImport) CountDocumentsInCosmosDb() error {
 	defer session.Close()
 
 	collection := session.DB(imp.ToolOptions.DB).C(imp.ToolOptions.Collection)
-	cosmosdb.VerifyDocumentCount(collection, imp.insertionCount)
+	if err := cosmosdb.GetDocumentCount(collection); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
mongoimport count check seems to be buggy, it sometimes thinks it ingested more document that it actually has, causing some confusion when it verifies against Cosmos DB.