### PR TITLE
Allow disabling of Index

### DIFF
--- a/common/cosmosdb/insertion_manager.go
+++ b/common/cosmosdb/insertion_manager.go
@@ -25,7 +25,7 @@ const (
 	workerScaleFactorWithIndex    = 1.45
 	workerScaleFactorWithoutIndex = 2.00
 	massHiringPercentage          = 0.7
-	massHiringMaxWorkerPerHire    = 400
+	massHiringMaxWorkerPerHire    = 200
 	massHiringSampleSize          = 5
 )
 
@@ -209,6 +209,10 @@ func (h *InsertionManager) launchMassHiringManager() {
 			log.Logv(log.Info, "Manager failed to mass hire new workers because: "+result.Error())
 			return
 		}
+		if amountToHire > massHiringMaxWorkerPerHire {
+			amountToHire = massHiringMaxWorkerPerHire
+			log.Logvf(log.Info, "Manager capped out hiring at %d new workers", amountToHire)
+		}
 		for i := 0; i < amountToHire; i++ {
 			h.HireNewWorker()
 		}
@@ -279,9 +283,6 @@ func (h *InsertionManager) signalSpeedup() {
 func (h *InsertionManager) filterMassHiringChoices(amountToHire int) error {
 	if amountToHire <= 0 {
 		return fmt.Errorf("manager has an overflow of workers")
-	}
-	if amountToHire > massHiringMaxWorkerPerHire {
-		return fmt.Errorf("manager attempted to hire too many workers")
 	}
 	if h.currentRateLimitCount() > 0 || h.slowDownCount > 0 {
 		return fmt.Errorf("manager was recently throttled")

--- a/common/options/options.go
+++ b/common/options/options.go
@@ -105,6 +105,7 @@ type General struct {
 	IgnoreSizeWarning    bool `long:"ignoreSizeWarning" default:"false" description:"Disable the size warning when importing into Azure Cosmos DB"`
 	DisableWorkerScaling bool `long:"disableWorkerScaling" default:"false" description:"Disable the scaling of Insertion workers"`
 	RunStockTool         bool `long:"runStockTool" default:"false" description:"Run this tool without any Azure Cosmos DB modifications"`
+	DropIndex            bool `long:"dropIndex" default:"false" description:"Drop Index"`
 }
 
 // Struct holding verbosity-related options

--- a/mongoimport/mongoimport.go
+++ b/mongoimport/mongoimport.go
@@ -445,7 +445,7 @@ func (imp *MongoImport) ingestDocumentsIntoCosmosDB(readDocs chan bson.D, cosmos
 		close(ingestionChannel)
 	}()
 
-	manager := cosmosdb.NewInsertionManager(ingestionChannel, cosmosDbCollection, imp.IngestOptions.StopOnError)
+	manager := cosmosdb.NewInsertionManager(ingestionChannel, cosmosDbCollection, imp.IngestOptions.StopOnError, imp.ToolOptions.General.DropIndex)
 	manager.SpecifySession = func() (*mgo.Session, error) {
 		session, err := imp.SessionProvider.GetSession()
 		if err != nil {

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -202,22 +202,24 @@ func (restore *MongoRestore) RestoreIntent(intent *intents.Intent) error {
 	}
 
 	var cosmosDbCollection *cosmosdb.CosmosDBCollection
+	if !restore.ToolOptions.RunStockTool {
+		session, serr := restore.SessionProvider.GetSession()
+		if serr != nil {
+			return serr
+		}
+
+		cosmosDbCollection = cosmosdb.NewCollection(
+			session.DB(intent.DB).C(intent.C),
+			restore.ToolOptions.General.Throughput,
+			restore.ToolOptions.General.ShardKey,
+		)
+	}
 	// TODO: Define logic to handle existing CosmosDB collection
 	if !collectionExists {
 		log.Logvf(log.Info, "creating collection %v %s", intent.Namespace(), logMessageSuffix)
 		log.Logvf(log.DebugHigh, "using collection options: %#v", options)
 		if !restore.ToolOptions.RunStockTool {
 			log.Logvf(log.Info, "We're targetting an Azure Cosmos DB URI; creating a custom collection...")
-			session, serr := restore.SessionProvider.GetSession()
-			if serr != nil {
-				return serr
-			}
-
-			cosmosDbCollection = cosmosdb.NewCollection(
-				session.DB(intent.DB).C(intent.C),
-				restore.ToolOptions.General.Throughput,
-				restore.ToolOptions.General.ShardKey,
-			)
 			if err := cosmosDbCollection.Deploy(); err != nil {
 				return err
 			}
@@ -314,6 +316,7 @@ func (restore *MongoRestore) RestoreCollectionToCosmosDB(cosmosDbCollection *cos
 			}
 		}
 		close(docChan)
+		log.Logvf(log.Info, "All bson has been loaded for insertion")
 	}()
 
 	log.Logvf(log.Info, "using %v insertion workers", maxInsertWorkers)
@@ -327,7 +330,7 @@ func (restore *MongoRestore) RestoreCollectionToCosmosDB(cosmosDbCollection *cos
 		close(ingestionChannel)
 	}()
 
-	manager := cosmosdb.NewInsertionManager(ingestionChannel, cosmosDbCollection, restore.OutputOptions.StopOnError)
+	manager := cosmosdb.NewInsertionManager(ingestionChannel, cosmosDbCollection, restore.OutputOptions.StopOnError, restore.ToolOptions.General.DropIndex)
 	manager.SpecifySession = func() (*mgo.Session, error) {
 		return session.Copy(), nil
 	}

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -316,7 +316,6 @@ func (restore *MongoRestore) RestoreCollectionToCosmosDB(cosmosDbCollection *cos
 			}
 		}
 		close(docChan)
-		log.Logvf(log.Info, "All bson has been loaded for insertion")
 	}()
 
 	log.Logvf(log.Info, "using %v insertion workers", maxInsertWorkers)


### PR DESCRIPTION
- Allow disabling of Index with `--dropIndex` flag for improved write performance of 3x at the trade-off of slower queries in the future.
- Fix mongorestore crashing when collection already exist