### PR TITLE
Adjust to latest MongoDB deployment on Cosmos DB

### DIFF
--- a/common/cosmosdb/insertion_worker.go
+++ b/common/cosmosdb/insertion_worker.go
@@ -82,6 +82,16 @@ func (iw *InsertionWorker) Run() error {
 	}
 }
 
+func (iw *InsertionWorker) handleRequestRateTooLarge(deadline time.Time) error {
+	iw.NotifyOfThrottle()
+	time.Sleep(5 * time.Millisecond)
+
+	if time.Now().After(deadline) {
+		return fmt.Errorf("ExceedInsertDeadline-Throughput")
+	}
+	return nil
+}
+
 func (iw *InsertionWorker) insert(doc interface{}) error {
 	// Prevent the retry from re-creating the insertOp object again by explicitly storing it
 	insertOperation := mgo.CreateInsertOp(iw.collection.FullName, doc)
@@ -94,12 +104,8 @@ retry:
 			switch qerr.Code {
 
 			case TooManyRequests:
-				log.Logv(log.Info, "Obtained RRTL")
-				iw.NotifyOfThrottle()
-				time.Sleep(5 * time.Millisecond)
-
-				if time.Now().After(tooManyRequestsDeadline) {
-					return fmt.Errorf("ExceedInsertDeadline-Throughput")
+				if timeout := iw.handleRequestRateTooLarge(tooManyRequestsDeadline); timeout != nil {
+					return timeout
 				}
 				goto retry
 
@@ -113,12 +119,14 @@ retry:
 			default:
 				log.Logvf(log.Always, "An unknown QuerryError occured: %d - %s", qerr.Code, err)
 			}
-		} else {
-			if strings.Contains(err.Error(), "Request rate is large") {
-				log.Logv(log.Info, "Obtained an non-query error RRTL")
+		} else if berr, ok := err.(*mgo.LastError); ok {
+			if berr.Code == TooManyRequests {
+				if timeout := iw.handleRequestRateTooLarge(tooManyRequestsDeadline); timeout != nil {
+					return timeout
+				}
+				goto retry
 			}
 		}
-
 	} else {
 		if iw.shouldSendStatistics {
 			requestCost, err := iw.collection.GetLastRequestStatistics()

--- a/common/cosmosdb/insertion_worker.go
+++ b/common/cosmosdb/insertion_worker.go
@@ -94,6 +94,7 @@ retry:
 			switch qerr.Code {
 
 			case TooManyRequests:
+				log.Logv(log.Info, "Obtained RRTL")
 				iw.NotifyOfThrottle()
 				time.Sleep(5 * time.Millisecond)
 
@@ -112,7 +113,12 @@ retry:
 			default:
 				log.Logvf(log.Always, "An unknown QuerryError occured: %d - %s", qerr.Code, err)
 			}
+		} else {
+			if strings.Contains(err.Error(), "Request rate is large") {
+				log.Logv(log.Info, "Obtained an non-query error RRTL")
+			}
 		}
+
 	} else {
 		if iw.shouldSendStatistics {
 			requestCost, err := iw.collection.GetLastRequestStatistics()

--- a/common/cosmosdb/util.go
+++ b/common/cosmosdb/util.go
@@ -2,7 +2,6 @@ package cosmosdb
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/globalsign/mgo"
@@ -30,9 +29,6 @@ func BenchmarkTime(start time.Time, name string) {
 }
 
 func FilterStandardErrors(stopOnError bool, err error) error {
-	if err.Error() == io.EOF.Error() {
-		return fmt.Errorf(db.ErrLostConnection)
-	}
 	if stopOnError || db.IsConnectionError(err) {
 		return err
 	}

--- a/vendor/src/github.com/globalsign/mgo/cluster.go
+++ b/vendor/src/github.com/globalsign/mgo/cluster.go
@@ -173,6 +173,8 @@ func (cluster *mongoCluster) isMaster(socket *mongoSocket, result *isMasterResul
 		// Include the application name if set
 		if cluster.appName != "" {
 			meta["application"] = bson.M{"name": cluster.appName}
+		} else {
+			meta["application"] = bson.M{"name": "cosmosdb-modified-mongo-tools"}
 		}
 
 		cmd = append(cmd, bson.DocElem{


### PR DESCRIPTION
- Include "Request too Large" check for LastError because Cosmos DB can now return Error Code inside `writeErrors` array which gets propagated into LastError
- Remove EOF error check as latest Cosmos DB deployment causes false positives; the worker still runs fine after the EOF
- Add user-agent like string into the mgo isMaster message